### PR TITLE
update: ajustando Workflow para publicar pré-release

### DIFF
--- a/.github/workflows/buildDoc.yml
+++ b/.github/workflows/buildDoc.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - main   # branch de testes (gera "latest")
+      - main   # branch de testes (gera "pre-release")
   workflow_dispatch:
     inputs:
       target_branch:
@@ -38,11 +38,11 @@ jobs:
           path: main.pdf
 
       # ===== RELEASE STABLE =====
-      - name: Publish Release (stable)
+      - name: Publish Release (latest)
         if: github.ref_name == 'main'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: stable
+          tag_name: latest
           name: TCC [PDF] (Stable)
           body: |
             PDF do TCC gerado automaticamente a partir do commit ${{ github.sha }}
@@ -52,11 +52,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.Publish_Release }}
 
       # ===== RELEASE LATEST =====
-      - name: Publish Release (latest)
+      - name: Publish Release (pre-release)
         if: github.ref_name == 'main'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
+          tag_name: pre-release
           name: TCC [PDF] (Latest)
           body: |
             PDF do TCC gerado automaticamente a partir do commit ${{ github.sha }}


### PR DESCRIPTION
Este PR implementa mudanças na pipeline CD do Latex, incluindo uma nova tag, `stable`.

Dessa foram a estrutura das releases é a seguinte:

## latest
Build a partir da main, somente. Última versão estável

## pre-release
Build de pré-release a partir de uma dada branch de iteração.